### PR TITLE
Better abort() and DNS error handling

### DIFF
--- a/main.c
+++ b/main.c
@@ -117,6 +117,13 @@ typedef struct dns_stats_t
     size_t nxdomain;
     size_t notimp;
     size_t refused;
+    size_t yxdomain;
+    size_t yxrrset;
+    size_t nxrrset;
+    size_t notauth;
+    size_t notzone;
+    size_t timeout;
+    size_t mismatch;    
     size_t other;
 } dns_stats_t;
 

--- a/main.c
+++ b/main.c
@@ -347,7 +347,7 @@ void print_stats(lookup_context_t *context)
     fprintf(print, "NXDOMAIN: %zu (%.2f%%)\n", stats.nxdomain, total == 0 ? 0 : (float) stats.nxdomain / total * 100);
     fprintf(print, "Final Timeout: %zu (%.2f%%)\n", stats.timeout, total == 0 ? 0 : (float) stats.timeout / (total+stats.timeout * 100));
     for(int i=0;i<context->cmd_args.resolve_count;i++){
-      fprintf(print, "%u: %u ,",i+1,timeout_stats[i]);
+      fprintf(print, "%u: %u (%.0f\%), ",i+1,timeout_stats[i],100*(float)timeout_stats[i]/timeout_stats[0]);
     }
     fprintf(print, "\n");
     fprintf(print, "Refused: %zu (%.2f%%)\n", stats.refused, total == 0 ? 0 : (float) stats.refused / total * 100);


### PR DESCRIPTION
Hi,

this request contains 3 things:

* More verbose stats
* "better" response handling, e.g. do not retry on SERVFAIL
* More verbose abort() handling, and in some cases just skipping the entry instead of exiting the program

Kind regards
Quirin