### PR TITLE
Makefile should respect $CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	mkdir -p bin
-	$(CC) -std=c11 -Wall -fstack-protector-strong *.c -o bin/massdns -lldns -ldl
+	$(CC) $(CFLAGS) -std=c11 -Wall -fstack-protector-strong *.c -o bin/massdns -lldns -ldl
 debug:
 	mkdir -p bin
-	$(CC) -std=c11 -Wall -g -DDEBUG *.c -o bin/massdns -lldns -ldl
+	$(CC) $(CFLAGS) -std=c11 -Wall -g -DDEBUG *.c -o bin/massdns -lldns -ldl


### PR DESCRIPTION
For example when compiling on OS X, I needed to pass the paths for the openssl lib. This was not possibly without extracting the commands from the Makefile.
This change should represent a reasonable change that can be found in many projects or tutorials, e.g.: http://www.delorie.com/djgpp/doc/ug/larger/makefiles.html