### PR TITLE
fixing possible bug affecting domains ending with .

### DIFF
--- a/main.c
+++ b/main.c
@@ -826,7 +826,7 @@ void massdns_scan(massdns_context_t *context)
                 if (line_len > 0 && line[line_len - 1] == '.')
                 {
                     // Remove trailing dot from FQDN
-                    line[line_len] = 0;
+                    line[line_len-1] = '\0';
                 }
                 lookup_t *lookup = hashmapGet(context->map, line);
                 if (lookup == NULL)


### PR DESCRIPTION
Hi, I think there was a bug in treating domains ending with '.' 
I am not sure what your code intended to do, but guess that replacing the '.' with '\0' would be reasonable?

Observable behaviour (reading test.de.) from STDIN before patch: massdns hanging up
After patch: Fine

Kind regards
Quirin