### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+LABEL maintainer Aditya Gujar (@aditya_gujar)
+
+RUN apt-get update
+
+RUN apt-get install -y libldns-dev git build-essential
+
+RUN apt-get install -y python
+
+RUN git clone https://github.com/blechschmidt/massdns.git
+
+WORKDIR /massdns/
+
+RUN make
+
+ENTRYPOINT ["./bin/massdns"]


### PR DESCRIPTION
I was having problems running massdns in Mac OS.
This Dockerfile creates an image and runs massdns.
Creating massdns image using this file is as simple as:
`docker build -t "massdns:latest" .`
Then run the image:
`docker run -i --rm massdns`
