### PR TITLE
ndjson format output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cmake-build-debug/
 *.igno
 *.ignore
 *.pyc
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "algorithm": "cpp"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.associations": {
-    "algorithm": "cpp"
-  }
-}

--- a/main.c
+++ b/main.c
@@ -1002,17 +1002,20 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
 
                 for(size_t rec_index = 0; dns_parse_record_raw(offset, next, offset + len, &next, &rec); rec_index++)
                 {
+                    char json_buffer[1024];
 
                     fprintf(context.outfile,
                             "{\"query_name\":\"%s\",\"query_type\":\"%s\",",
                             dns_name2str(&packet.head.question.name),
                             dns_record_type2str((dns_record_type) packet.head.question.type));
 
+                    string_escape(&json_buffer[0], dns_raw_record_data2str(&rec, offset, offset + short_len), 1024);
+
                     fprintf(context.outfile,
                             "\"resp_name\":\"%s\",\"resp_type\":\"%s\",\"data\":\"%s\"}\n",
                             dns_name2str(&rec.name),
                             dns_record_type2str((dns_record_type) rec.type),
-                            dns_raw_record_data2str(&rec, offset, offset + short_len));
+                            json_buffer);
                 }
 
                 break;

--- a/main.c
+++ b/main.c
@@ -71,6 +71,7 @@ void print_help()
                     "  S - simple text output\n"
                     "  F - full text output\n"
                     "  B - binary output\n"
+                    "  J - ndjson output\n"
                     "\n"
                     "Advanced flags for the simple output mode:\n"
                     "  d - Include records from the additional section.\n"
@@ -997,6 +998,25 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                 dns_print_packet(context.outfile, &packet, offset, len, next);
                 break;
 
+            case OUTPUT_NDJSON: // Only print records from answer section that match the query name (in ndjson)
+
+                for(size_t rec_index = 0; dns_parse_record_raw(offset, next, offset + len, &next, &rec); rec_index++)
+                {
+
+                    fprintf(context.outfile,
+                            "{\"query_name\":\"%s\",\"query_type\":\"%s\",",
+                            dns_name2str(&packet.head.question.name),
+                            dns_record_type2str((dns_record_type) packet.head.question.type));
+
+                    fprintf(context.outfile,
+                            "\"resp_name\":\"%s\",\"resp_type\":\"%s\",\"data\":\"%s\"}\n",
+                            dns_name2str(&rec.name),
+                            dns_record_type2str((dns_record_type) rec.type),
+                            dns_raw_record_data2str(&rec, offset, offset + short_len));
+                }
+
+                break;
+    
             case OUTPUT_TEXT_SIMPLE: // Only print records from answer section that match the query name
                 if(context.format.print_question)
                 {
@@ -1828,6 +1848,10 @@ int parse_cmd(int argc, char **argv)
             {
                 case 'B':
                     context.cmd_args.output = OUTPUT_BINARY;
+                    break;
+
+                case 'J':
+                    context.cmd_args.output = OUTPUT_NDJSON;
                     break;
 
                 case 'S':

--- a/massdns.h
+++ b/massdns.h
@@ -105,7 +105,8 @@ typedef enum
 {
     OUTPUT_TEXT_FULL,
     OUTPUT_TEXT_SIMPLE,
-    OUTPUT_BINARY
+    OUTPUT_BINARY,
+    OUTPUT_NDJSON
 } output_t;
 
 const char *default_interfaces[] = {""};

--- a/string.h
+++ b/string.h
@@ -112,4 +112,81 @@ bool startswith(char* haystack, char* needle, bool case_sensitive) // Supports A
     }
 }
 
+// JSON requires some escaping
+// https://stackoverflow.com/users/10320/dreamlax
+size_t string_escape(char *dst, const char *src, size_t dstLen)
+{
+    const char complexCharMap[] = "abtnvfr";
+
+    size_t i;
+    size_t srcLen = strlen(src);    
+    size_t dstIdx = 0;
+
+    if (dst == NULL || dstLen == 0) dstLen = SIZE_MAX;
+
+    for (i = 0; i < srcLen && dstIdx < dstLen; i++)
+    {
+        size_t complexIdx = 0;
+
+        switch (src[i])
+        {
+            case '\'':
+            case '\"':
+            case '\\':
+                if (dst && dstIdx <= dstLen - 2)
+                {
+                    dst[dstIdx++] = '\\';
+                    dst[dstIdx++] = src[i];
+                }
+                else dstIdx += 2;
+                break;
+
+            case '\r': complexIdx++;
+            case '\f': complexIdx++;
+            case '\v': complexIdx++;
+            case '\n': complexIdx++;
+            case '\t': complexIdx++;
+            case '\b': complexIdx++;
+            case '\a':
+                if (dst && dstIdx <= dstLen - 2)
+                {
+                    dst[dstIdx++] = '\\';
+                    dst[dstIdx++] = complexCharMap[complexIdx];
+                }
+                else dstIdx += 2;
+                break;
+
+            default:
+                if (isprint(src[i]))
+                {
+                    // simply copy the character
+                    if (dst)
+                        dst[dstIdx++] = src[i];
+                    else
+                        dstIdx++;
+                }
+                else
+                {
+                    // produce octal escape sequence
+                    if (dst && dstIdx <= dstLen - 4)
+                    {
+                        dst[dstIdx++] = '\\';
+                        dst[dstIdx++] = ((src[i] & 0300) >> 6) + '0';
+                        dst[dstIdx++] = ((src[i] & 0070) >> 3) + '0';
+                        dst[dstIdx++] = ((src[i] & 0007) >> 0) + '0';
+                    }
+                    else
+                    {
+                        dstIdx += 4;
+                    }
+                }
+        }
+    }
+
+    if (dst && dstIdx <= dstLen)
+        dst[dstIdx] = '\0';
+
+    return dstIdx;
+}
+
 #endif


### PR DESCRIPTION
Added a new output format that produces [ndjson](http://ndjson.org/) output for basic queries (mostly equivalent to `-o Snq`) and responses for easier ingestion into data science workflows.

e.g.

```json
{"query_name":"www.hpe.com.","query_type":"A","resp_name":"c.gtld-servers.net.","resp_type":"A","data":"192.26.92.30"}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"www.ugicorp.com.","resp_type":"CNAME","data":"webfarm-36.q4web.com."}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"webfarm-36.q4web.com.","resp_type":"CNAME","data":"webfarm-100.q4web.com."}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"webfarm-100.q4web.com.","resp_type":"CNAME","data":"dosarrest241.web.q4inc.com."}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"dosarrest241.web.q4inc.com.","resp_type":"A","data":"69.172.200.241"}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"web.q4inc.com.","resp_type":"NS","data":"ns-1948.awsdns-51.co.uk."}
{"query_name":"www.ugicorp.com.","query_type":"A","resp_name":"web.q4inc.com.","resp_type":"NS","data":"ns-883.awsdns-46.net."}
```

Tested on Ubuntu Xenial.