### PR TITLE
Support list of dedicated resolvers/nameservers in domains file

### DIFF
--- a/main.c
+++ b/main.c
@@ -88,6 +88,21 @@ void print_help()
     );
 }
 
+void free_lookup(lookup_t *lookup)
+{
+    // free the nameservers array
+    if(lookup->nameservers)
+    {
+        int i;
+        for (i = 0; *(lookup->nameservers + i); i++)
+        {
+            free(*(lookup->nameservers + i));
+        }
+        free(lookup->nameservers);
+        lookup->nameservers = NULL;
+    }
+}
+
 void cleanup()
 {
 #ifdef PCAP_SUPPORT
@@ -98,6 +113,17 @@ void cleanup()
 #endif
     if(context.map)
     {
+        // free the nameservers array
+        int i;
+        for (i = 0; i < context.map->bucketCount; i++)
+        {
+            Entry* entry = context.map->buckets[i];
+            while (entry != NULL)
+            {
+                free_lookup((lookup_t *) entry->value);
+                entry = entry->next;
+            }
+        }
         hashmapFree(context.map);
     }
 
@@ -397,9 +423,9 @@ void query_sockets_setup()
     }
 }
 
-bool next_query(char **qname)
+bool next_query(char **qname, char ***nameservers)
 {
-    static char line[512];
+    static char line[2048];
     static size_t line_index = 0;
 
     while (fgets(line, sizeof(line), context.domainfile))
@@ -417,7 +443,26 @@ bool next_query(char **qname)
         {
             continue;
         }
-        *qname = line;
+        char** parts;
+        char* line_copy = strmcpy(line);
+        parts = str_split(line_copy, ' ');
+        char* domain = strmcpy(*parts);
+        *qname = domain;
+        // check if there are nameservers
+        if (*(parts + 1))
+        {
+            // copy the array without the first element to a new array
+            int num_nameservers;
+            for (num_nameservers = 0; *(parts + num_nameservers + 1); num_nameservers++){}
+            *nameservers = malloc(sizeof(char*) * (num_nameservers + 1));
+            memcpy(*nameservers, parts + 1, sizeof(char*) * num_nameservers);
+            *(*nameservers + num_nameservers) = 0;
+        } else {
+            *nameservers = 0;
+        }
+        free(line_copy);
+        free(*parts);
+        free(parts);
 
         return true;
     }
@@ -509,6 +554,26 @@ lookup_t *new_lookup(const char *qname, dns_record_type type, bool *new)
     return value;
 }
 
+
+resolver_t* create_resolver_from_nameserver(char *nameserver)
+{
+    resolver_t *resolver = safe_calloc(sizeof(*resolver));
+    struct sockaddr_storage *addr = &resolver->address;
+    if (str_to_addr(nameserver, 53, addr))
+    {
+        if(!(addr->ss_family == AF_INET && context.sockets.interfaces4.len > 0)
+            && !(addr->ss_family == AF_INET6 && context.sockets.interfaces6.len > 0))
+        {
+            log_msg("No query socket for resolver \"%s\" found.\n", nameserver);
+        }
+    }
+    else
+    {
+        log_msg("\"%s\" is not a valid resolver. Skipped.\n", nameserver);
+    }
+    return resolver;
+}
+
 void send_query(lookup_t *lookup)
 {
     static uint8_t query_buffer[0x200];
@@ -517,7 +582,12 @@ void send_query(lookup_t *lookup)
     // Pool of resolvers cannot be empty due to check after parsing resolvers.
     if(!context.cmd_args.sticky || lookup->resolver == NULL)
     {
-        if(context.cmd_args.predictable_resolver)
+        if(lookup->nameservers && *(lookup->nameservers + lookup->nameserver_index))
+        {
+            lookup->resolver = create_resolver_from_nameserver(*(lookup->nameservers + lookup->nameserver_index));
+            lookup->nameserver_index++;
+        }
+        else if(context.cmd_args.predictable_resolver)
         {
             lookup->resolver = ((resolver_t *) context.resolvers.data) + context.lookup_index % context.resolvers.len;
         }
@@ -829,17 +899,22 @@ void done()
 void can_send()
 {
     char *qname;
+    char **nameservers;
     bool new;
 
     while (hashmapSize(context.map) < context.cmd_args.hashmap_size && context.state <= STATE_QUERYING)
     {
-        if(!next_query(&qname))
+        if(!next_query(&qname, &nameservers))
         {
             context.state = STATE_COOLDOWN; // We will not create any new queries
             break;
         }
         context.stats.numdomains++;
         lookup_t *lookup = new_lookup(qname, context.cmd_args.record_type, &new);
+        if (nameservers)
+        {
+            lookup->nameservers = nameservers;
+        }
         if(!new)
         {
             continue;
@@ -855,8 +930,18 @@ bool is_unacceptable(dns_pkt_t *packet)
 
 void lookup_done(lookup_t *lookup)
 {
+    int i;
     context.stats.finished++;
 
+    // free the nameservers array
+    if (lookup->nameservers)
+    {
+        for (i = 0; *(lookup->nameservers + i); i++)
+        {
+            free(*(lookup->nameservers + i));
+        }
+        free(lookup->nameservers);
+    }
     hashmapRemove(context.map, lookup->key);
 
     // Return lookup to pool.

--- a/massdns.h
+++ b/massdns.h
@@ -84,6 +84,8 @@ typedef struct
     uint16_t transaction;
     void **ring_entry; // pointer to the entry within the timed ring for entry invalidation
     resolver_t *resolver;
+    char **nameservers;
+    size_t nameserver_index;
     lookup_key_t *key;
     socket_info_t *socket;
 } lookup_t;

--- a/string.h
+++ b/string.h
@@ -165,3 +165,51 @@ json_escape_finalize:
 }
 
 #endif
+
+char** str_split(char* a_str, const char a_delim)
+{
+    char** result    = 0;
+    size_t count     = 0;
+    char* tmp        = a_str;
+    char* last_comma = 0;
+    char delim[2];
+    delim[0] = a_delim;
+    delim[1] = 0;
+
+    /* Count how many elements will be extracted. */
+    while (*tmp)
+    {
+        if (a_delim == *tmp)
+        {
+            count++;
+            last_comma = tmp;
+        }
+        tmp++;
+    }
+
+    /* Add space for trailing token. */
+    count += last_comma < (a_str + strlen(a_str) - 1);
+
+    /* Add space for terminating null string so caller
+       knows where the list of returned strings ends. */
+    count++;
+
+    result = malloc(sizeof(char*) * count);
+    
+    if (result)
+    {
+        size_t idx  = 0;
+        char* token = strtok(a_str, delim);
+
+        while (token)
+        {
+            assert(idx < count);
+            *(result + idx++) = strmcpy(token);
+            token = strtok(0, delim);
+        }
+        assert(idx == count - 1);
+        *(result + idx) = 0;
+    }
+
+    return result;
+}


### PR DESCRIPTION
Yet another enhancement PR: if you know the dedicated resolvers per domain it would be nice to be able to specify those as well in the domains file.
Suggested implementation: space separated list of dedicated resolver after the domain on the same line in the domains input file.