### PR TITLE
Adding "\n" to subbrute

### DIFF
--- a/scripts/subbrute.py
+++ b/scripts/subbrute.py
@@ -8,4 +8,4 @@ if len(sys.argv) < 3:
 for lines in open(sys.argv[1]):
 	for arg in sys.argv[2:]:
 		if lines.strip() != "":
-			print(lines.strip() + "." + arg)
+			print(lines.strip() + "." + arg + "\n")


### PR DESCRIPTION
While I was using subbrute script, I noticed all the domains were concatenated, there was now new line between the domains printed out. Trying to find out why, all I had to do was to had a "\n" to the script and it all got fixed up!