### PR TITLE
Json stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are not on Linux, run `make nolinux`. On Windows, the `Cygwin` packages `
 
 ## Usage
 ```
-Usage: ./bin/massdns [options] [domainlist]
+Usage: bin/massdns [options] [domainlist]
   -b  --bindto           Bind to IP address and port. (Default: 0.0.0.0:0)
       --busy-poll        Use busy-wait polling instead of epoll.
   -c  --resolve-count    Number of resolves for a name before giving up. (Default: 50)
@@ -46,6 +46,7 @@ Usage: ./bin/massdns [options] [domainlist]
       --root             Do not drop privileges when running as root. Not recommended.
   -s  --hashmap-size     Number of concurrent lookups. (Default: 10000)
       --sndbuf           Size of the send buffer in bytes.
+      --status-format    Format for real-time status updates, json or ansi (Default: ansi)
       --sticky           Do not switch the resolver when retrying.
       --socket-count     Socket count per process. (Default: 1)
   -t  --type             Record type to be resolved. (Default: A)
@@ -57,7 +58,20 @@ Output flags:
   F - full text output
   B - binary output
   J - ndjson output
+
+Advanced flags for the simple output mode:
+  d - Include records from the additional section.
+  i - Indent any reply record.
+  l - Separate replies using a line feed.
+  m - Only output reply records that match the question name.
+  n - Include records from the answer section.
+  q - Print the question.
+  r - Prepend resolver IP address, Unix timestamp and return code to the question line.
+  s - Separate packet sections using a line feed.
+  t - Include TTL and record class within the output.
+  u - Include records from the authority section.
 ```
+
 This overview may be incomplete. For more options, especially concerning output formatting, use `--help`.
 
 ### Example

--- a/massdns.h
+++ b/massdns.h
@@ -111,6 +111,11 @@ typedef enum
     OUTPUT_NDJSON
 } output_t;
 
+typedef struct {
+    const char *name;
+    const char *status_fmt;
+} status_format_map_t;
+
 const char *default_interfaces[] = {""};
 
 typedef struct
@@ -129,7 +134,6 @@ typedef struct
     struct
     {
         bool sections[4];
-
         bool match_name;
         bool ttl;
         bool separate_queries;
@@ -188,7 +192,7 @@ typedef struct
     size_t finished;
     pid_t *pids;
     bool *done;
-
+    const char *status_fmt;
     FILE* outfile;
     FILE* logfile;
     FILE* domainfile;


### PR DESCRIPTION
This PR has two things:

1. Addition of --status-format {ansi, json} as an optional argument. This provides the user an option of having a single line of JSON output at every tick as opposed to the default behavior which is a very readable human oriented format with ansi terminal escapes. Useful if monitoring massdns programmatically over a long run
2. Updated the README.md to show the *current* output of the massdns help screen. It looks like it did not get updated after v0.2

This change should not affect any users. If the argument is not provided, it defaults to the current ansi-style format string.

Please let me know if you have issues with the implementation or style.

Thanks, excellent tool. By the way, any plans in the future to split it out into a sender/receiver thread to see if you can squeeze out some better performance?