### PR TITLE
ndjson output add ttl value

### DIFF
--- a/main.c
+++ b/main.c
@@ -1067,9 +1067,10 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                     json_escape(json_buffer, dns_raw_record_data2str(&rec, offset, offset + short_len), sizeof(json_buffer));
 
                     fprintf(context.outfile,
-                            "\"resp_name\":\"%s\",\"resp_type\":\"%s\",\"data\":\"%s\"}\n",
+                            "\"resp_name\":\"%s\",\"resp_type\":\"%s\",\"resp_ttl\":\"%d\",\"data\":\"%s\"}\n",
                             dns_name2str(&rec.name),
                             dns_record_type2str((dns_record_type) rec.type),
+                            rec.ttl,
                             json_buffer);
                 }
 


### PR DESCRIPTION
The TTL value has a certain reference role in judging whether the subdomain is pan-parsed in the scene of subdomain enumeration. It is recommended that the ttl value be written to the json output result by default. For details, please refer to:http://sh3ll.me/archives/201704041222.txt

Thank you for open source this great tool, I very much hope that the output will have a TTL value.
Note: Compiled and tested without problems.