### PR TITLE
Fix domain extraction in crt.py

### DIFF
--- a/scripts/ct.py
+++ b/scripts/ct.py
@@ -4,7 +4,6 @@ import sys
 import urllib.request
 import urllib.parse
 import json
-import re
 
 
 if len(sys.argv) == 1:

--- a/scripts/ct.py
+++ b/scripts/ct.py
@@ -3,6 +3,7 @@
 import sys
 import urllib.request
 import urllib.parse
+import json
 import re
 
 
@@ -12,10 +13,10 @@ if len(sys.argv) == 1:
 
 for i, arg in enumerate(sys.argv, 1):
 	domains = set()
-	with urllib.request.urlopen('https://crt.sh/?q=' + urllib.parse.quote('%.' + arg)) as f:
-		code = f.read().decode('utf-8')
-		for cert, domain in re.findall('<tr>(?:\s|\S)*?href="\?id=([0-9]+?)"(?:\s|\S)*?<td>([*_a-zA-Z0-9.-]+?\.' + re.escape(arg) + ')</td>(?:\s|\S)*?</tr>', code, re.IGNORECASE):
-			domain = domain.split('@')[-1]
-			if not domain in domains:
-				domains.add(domain)
-				print(domain)
+	with urllib.request.urlopen('https://crt.sh/?output=json&q=' + urllib.parse.quote('%.' + arg)) as f:
+		data = json.loads(f.read().decode('utf-8'))
+		for crt in data:
+			for domain in crt['name_value'].split('\n'):
+				if not domain in domains:
+					domains.add(domain)
+					print(domain)


### PR DESCRIPTION
## Problem
I've found a bug when running ctr.py.
This domain is properly extracted from crt.sh:
```html
<tr>subdomain.example.com</tr>
```
But these domains are ignored:
```html
<tr>subdomain1.example.com<br>subdomain2.example.com</tr>
```

## Solution
The query parameter `output=json` was added and all domains were extracted correctly.