### PR TITLE
dns_print_readable: More Significant bits always zero, only shift by 4

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -1270,7 +1270,7 @@ bool dns_print_readable(char **buf, size_t buflen, const uint8_t *source, size_t
             }
             *((*buf)++) = '\\';
             *((*buf)++) = 'x';
-            char hex1 = (char)((source[i] >> 8) & 0xF);
+            char hex1 = (char)((source[i] >> 4) & 0xF);
             char hex2 = (char)(source[i] & 0xF);
             *((*buf)++) = (char)(hex1 + (hex1 < 10 ? '0' : ('a' - 10)));
             *((*buf)++) = (char)(hex2 + (hex2 < 10 ? '0' : ('a' - 10)));


### PR DESCRIPTION
At the moment, the more significant bits of each byte are 0 after dns_print_readable.
Each byte is shifted by 8 instead of 4 always resulting in 0.