### PR TITLE
Output answer record name in ndjson instead of question

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1124,7 +1124,7 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                     {
                         fputs(",", context.outfile);
                     }
-                    json_escape_str(json_buffer, sizeof(json_buffer), dns_name2str(&packet.head.question.name));
+                    json_escape_str(json_buffer, sizeof(json_buffer), dns_name2str(&rec.name));
 
                     fprintf(context.outfile,
                             "{\"ttl\":%" PRIu32 ",\"type\":\"%s\",\"class\":\"%s\",\"name\":\"%s\",\"data\":\"",


### PR DESCRIPTION
I think that the answer name in the ndjson output is wrong. Given the following DNS response:

```
$ dig A mail.google.com

; <<>> DiG 9.11.5-P4-5.1+deb10u2-Debian <<>> A mail.google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 41651
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;mail.google.com.               IN      A

;; ANSWER SECTION:
mail.google.com.        5       IN      CNAME   googlemail.l.google.com.
googlemail.l.google.com. 4      IN      A       172.217.22.37

;; Query time: 22 msec
;; SERVER: 192.168.168.1#53(192.168.168.1)
;; WHEN: Fri Nov 20 08:23:11 CET 2020
;; MSG SIZE  rcvd: 87

```

Results in this JSON output:

```json
{
  "name": "mail.google.com.",
  "type": "A",
  "class": "IN",
  "status": "NOERROR",
  "data": {
    "answers": [
      {
        "ttl": 20603,
        "type": "CNAME",
        "class": "IN",
        "name": "mail.google.com.",
        "data": "googlemail.l.google.com."
      },
      {
        "ttl": 299,
        "type": "A",
        "class": "IN",
        "name": "mail.google.com.",
        "data": "172.217.19.69"
      }
    ]
  },
  "resolver": "8.8.8.8:53"
}
```

Instead the name fields in the answer section should reflect the actual name of the answer, right?


```json
{
  "name": "mail.google.com.",
  "type": "A",
  "class": "IN",
  "status": "NOERROR",
  "data": {
    "answers": [
      {
        "ttl": 19915,
        "type": "CNAME",
        "class": "IN",
        "name": "mail.google.com.",
        "data": "googlemail.l.google.com."
      },
      {
        "ttl": 268,
        "type": "A",
        "class": "IN",
        "name": "googlemail.l.google.com.",
        "data": "172.217.19.69"
      }
    ]
  },
  "resolver": "8.8.4.4:53"
}
```
