### PR TITLE
Python script to fetch public IPv4 DNS servers with high reliability

### DIFF
--- a/scripts/get-resolvers.py
+++ b/scripts/get-resolvers.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+import requests
+import validators
+import json
+
+NAMESERVERS_URL='https://public-dns.info/nameserver/nameservers.json'
+OUTPUT_FILE=os.path.dirname(os.path.realpath(__file__)) + "/../lists/public-dns.txt"
+MIN_RELIABILIY=0.99
+
+try:
+
+    # Try to open output file for writing
+    with open(OUTPUT_FILE, 'w') as f:
+        # Fetch public servers
+        r = requests.get(NAMESERVERS_URL)
+        for ip in json.loads(r.text):
+            # Only focus on reliable ipv4 addresses
+            if validators.ipv4(ip['ip']) and ip['reliability'] > MIN_RELIABILIY:
+                # Write results
+                f.write("%s\n" % ip['ip'])
+
+except Exception as e:
+    print("Error.")


### PR DESCRIPTION
Added a python script to fetch IPv4 DNS Servers and filter for high reliability addresses (>0.99).

Requires python3 and requests + validators modules.

Can replace get-resolvers.sh, which doesn't offer filtering for IPv4 or reliability.