### PR TITLE
Only remove quotes  around txt record value in ndjson output mode #103

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -1342,7 +1342,7 @@ void dns_question2str(dns_question_t *question, char *buf, size_t len)
              dns_record_type2str(question->type));
 }
 
-char* dns_raw_record_data2str(dns_record_t *record, uint8_t *begin, uint8_t *end)
+char* dns_raw_record_data2str(dns_record_t *record, uint8_t *begin, uint8_t *end, bool put_quotes)
 {
     static char buf[0xFFFF0];
     static dns_name_t name;
@@ -1377,8 +1377,13 @@ char* dns_raw_record_data2str(dns_record_t *record, uint8_t *begin, uint8_t *end
                 uint8_t length = *(data_ptr++);
                 if (data_ptr + length <= record_end)
                 {
+                    if (put_quotes) *(ptr++) = '"';
                     dns_print_readable(&ptr, sizeof(buf), data_ptr, length, false);
                     data_ptr += length;
+                    if (put_quotes){
+                        *(ptr++) = '"';
+                        *(ptr++) = ' ';
+                    }
                 }
                 else
                 {
@@ -1566,7 +1571,7 @@ void dns_print_packet(FILE *f, dns_pkt_t *packet, uint8_t *begin, size_t len, ui
                 rec.ttl,
                 dns_class2str((dns_class)rec.class),
                 dns_record_type2str((dns_record_type) rec.type),
-                dns_raw_record_data2str(&rec, begin, begin + len));
+                dns_raw_record_data2str(&rec, begin, begin + len, true));
     }
     fprintf(f, "\n\n");
 }

--- a/src/dns.h
+++ b/src/dns.h
@@ -1377,11 +1377,8 @@ char* dns_raw_record_data2str(dns_record_t *record, uint8_t *begin, uint8_t *end
                 uint8_t length = *(data_ptr++);
                 if (data_ptr + length <= record_end)
                 {
-                    *(ptr++) = '"';
                     dns_print_readable(&ptr, sizeof(buf), data_ptr, length, false);
                     data_ptr += length;
-                    *(ptr++) = '"';
-                    *(ptr++) = ' ';
                 }
                 else
                 {

--- a/src/main.c
+++ b/src/main.c
@@ -1136,7 +1136,7 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                             json_buffer);
                     section_emitted = true;
                     json_escape_str(json_buffer, sizeof(json_buffer),
-                                    dns_raw_record_data2str(&rec, offset, offset + short_len));
+                                    dns_raw_record_data2str(&rec, offset, offset + short_len, false));
                     fputs(json_buffer, context.outfile);
                     fprintf(context.outfile, "\"}");
                 }
@@ -1206,7 +1206,7 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                                 context.format.indent_sections ? "\t" : "",
                                 dns_name2str(&rec.name),
                                 dns_record_type2str((dns_record_type) rec.type),
-                                dns_raw_record_data2str(&rec, offset, offset + short_len));
+                                dns_raw_record_data2str(&rec, offset, offset + short_len, true));
                     }
                     else
                     {
@@ -1218,7 +1218,7 @@ void do_read(uint8_t *offset, size_t len, struct sockaddr_storage *recvaddr)
                                 dns_class2str((dns_class)rec.class),
                                 rec.ttl,
                                 dns_record_type2str((dns_record_type) rec.type),
-                                dns_raw_record_data2str(&rec, offset, offset + short_len));
+                                dns_raw_record_data2str(&rec, offset, offset + short_len, true));
                     }
                 }
                 if(context.format.separate_queries)


### PR DESCRIPTION
Hi @blechschmidt,  

Hope this time I made it . This pr makes changes for removing quotes around txt value only in ndjson mode. A new parameter added to dns_raw_record_data2str #103 