### PR TITLE
support list of dedicated resolvers/nameservers in domains file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -413,6 +413,16 @@ buffer_t resolvers_from_line(char *line, char **qname)
                     || (addr->ss_family == AF_INET6 && context.sockets.interfaces6.len > 0))
                 {
                     single_list_push_back(list, resolver);
+                    if (context.cmd_args.verify_ip)
+                    {
+                        errno = 0;
+                        hashmapPut(context.resolver_map, &resolver->address, resolver);
+                        if (errno != 0)
+                        {
+                            log_msg("Error putting resolver into hashmap: %s\n", strerror(errno));
+                            abort();
+                        }
+                    }
                 }
                 else
                 {

--- a/src/main.c
+++ b/src/main.c
@@ -659,7 +659,7 @@ void send_query(lookup_t *lookup)
     // Pool of resolvers cannot be empty due to check after parsing resolvers.
     if(!context.cmd_args.sticky || lookup->resolver == NULL)
     {
-        if(lookup->dedicated_resolvers.len > 0 && lookup->dedicated_resolver_index + 1 < lookup->dedicated_resolvers.len)
+        if(lookup->dedicated_resolvers.len > 0 && lookup->dedicated_resolver_index < lookup->dedicated_resolvers.len)
         {
             lookup->resolver = ((resolver_t *) lookup->dedicated_resolvers.data) + lookup->dedicated_resolver_index;
             lookup->dedicated_resolver_index++;

--- a/src/main.c
+++ b/src/main.c
@@ -979,7 +979,10 @@ void can_send()
         }
         context.stats.numdomains++;
         lookup_t *lookup = new_lookup(qname, context.cmd_args.record_type, &new);
-        lookup->dedicated_resolvers = dedicated_resolvers;
+        if (lookup != NULL)
+        {
+            lookup->dedicated_resolvers = dedicated_resolvers;
+        }
         if(!new)
         {
             continue;

--- a/src/massdns.h
+++ b/src/massdns.h
@@ -85,6 +85,8 @@ typedef struct
     uint16_t transaction;
     void **ring_entry; // pointer to the entry within the timed ring for entry invalidation
     resolver_t *resolver;
+    buffer_t dedicated_resolvers;
+    size_t dedicated_resolver_index;
     lookup_key_t *key;
     socket_info_t *socket;
 } lookup_t;

--- a/src/string.h
+++ b/src/string.h
@@ -178,3 +178,54 @@ size_t json_escape(char *dst, size_t dst_len, const uint8_t *src, size_t src_len
 #undef json_escape_body
 
 #endif
+
+char** str_split(char* a_str, const char a_delim)
+{
+    char** result    = 0;
+    size_t count     = 0;
+    char* tmp        = a_str;
+    char* last_comma = 0;
+    char delim[2];
+    delim[0] = a_delim;
+    delim[1] = 0;
+
+    /* Count how many elements will be extracted. */
+    while (*tmp)
+    {
+        if (a_delim == *tmp)
+        {
+            // count multiple delimiters in a row only once
+            if (last_comma + 1 < tmp)
+            {
+                count++;
+            }
+            last_comma = tmp;
+        }
+        tmp++;
+    }
+
+    /* Add space for trailing token. */
+    count += last_comma < (a_str + strlen(a_str) - 1);
+
+    /* Add space for terminating null string so caller
+       knows where the list of returned strings ends. */
+    count++;
+
+    result = malloc(sizeof(char*) * count);
+
+    if (result)
+    {
+        size_t idx  = 0;
+        char* token = strtok(a_str, delim);
+        while (token)
+        {
+            assert(idx < count);
+            *(result + idx++) = strmcpy(token);
+            token = strtok(0, delim);
+        }
+        assert(idx == count - 1);
+        *(result + idx) = 0;
+    }
+
+    return result;
+}


### PR DESCRIPTION
See #49
I finally got some time to implement it with `buffer_t` struct for the resolvers per entry.
As I have very limited experience with coding C, it would be good to do a proper review of the code :-)

Also, you might want to add a command line option to enable this feature?