### PR TITLE
Remove additional `--update` for `apk` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:edge
 
-RUN apk --update --no-cache --virtual .build-deps add git build-base \
+RUN apk --no-cache --virtual .build-deps add git build-base \
    && git clone --depth=1 https://github.com/blechschmidt/massdns.git \
    && cd massdns && make && apk del .build-deps
 


### PR DESCRIPTION
There is no need to use `--update` with `--no-cache` when using `apk` on Alpine Linux, as using `--no-cache` will fetch the index every time and leave no local cache, so the index will always be the latest without temporary files remains in the image.