### PR TITLE
Read random IPv6 source addresses from a file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -887,17 +887,17 @@ int load_random_addr(char* file_name)
 
         if (inet_pton(AF_INET6, ipv6_str, &context.srcrand.loaded_v6_address[count].sin6_addr) <= 0)
         {
-            fprintf(stderr, "Ignoring invalid IPv6 address: %s\n", ipv6_str);
+            log_msg(LOG_ERROR, "Ignoring invalid random source IPv6 address: %s\n", ipv6_str);
             continue;
         }
 
         context.srcrand.loaded_v6_address[count].sin6_family = AF_INET6;
-        context.srcrand.loaded_v6_address[count].sin6_port = htons(0); // Set to 0 or desired port
+        context.srcrand.loaded_v6_address[count].sin6_port = htons(0);
 
         count++;
         if (count >= MAX_RANDOM_V6_ADDRESSES)
         {
-            fprintf(stderr, "Reached maximum random IPv6 address limit\n");
+            log_msg(LOG_ERROR, "Reached maximum random IPv6 address limit\n", ipv6_str);
             break;
         }
     }

--- a/src/massdns.h
+++ b/src/massdns.h
@@ -32,6 +32,8 @@
 #define LOG_ERROR 3
 
 #define LOGLEVEL LOG_WARN
+#define MAX_RANDOM_V6_ADDRESSES 10000
+
 
 const uint32_t OUTPUT_BINARY_VERSION = 0x00;
 
@@ -256,7 +258,10 @@ typedef struct
     size_t fork_index;
     struct {
         bool enabled;
+        bool read_from_file;
         struct sockaddr_storage src_range;
+        int available_random_v6_addresses;
+        struct sockaddr_in6 loaded_v6_address[MAX_RANDOM_V6_ADDRESSES];
     } srcrand;
     struct
     {

--- a/src/random.h
+++ b/src/random.h
@@ -61,4 +61,16 @@ int urandom_close()
     return fclose(randomness);
 }
 
+int urandom_get_int(int min, int max)
+{
+    int n = max - min + 1;
+    int remainder = RAND_MAX % n;
+    int x;
+    do
+    {
+        x = rand();
+    } while (x >= RAND_MAX - remainder);
+    return min + x % n;
+}
+
 #endif //MASSRESOLVER_RANDOM_H


### PR DESCRIPTION
Changes: 
Accepts a list of source ipv6 address from a file for making DNS queries.

Rationale:
VPS providers often provide a /64 IPv6 prefix but don't route the entire prefix to the allocated machine, but we can manually allocate many addresses to our network interface with ```ip addr add <addr in from> dev eth0``` which then undergo the 'NDP process' and become routable, same set of addresses can be fed into massdns to bypass rate limits.