### PR TITLE
add requirements for scripts

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,3 @@
 requests
+dnspython
+psutil


### PR DESCRIPTION
dnspython and psutil libraries required by recon.py script. Added these to the requirements.txt file.